### PR TITLE
RP2040: Add support for the RP2040.

### DIFF
--- a/src/AsyncMqttClient.hpp
+++ b/src/AsyncMqttClient.hpp
@@ -10,6 +10,8 @@
 #include <freertos/semphr.h>
 #elif defined(ESP8266)
 #include <ESPAsyncTCP.h>
+#elif defined(USE_RP2040)
+#include <AsyncTCP_RP2040W.h>
 #else
 #error Platform not supported
 #endif
@@ -42,6 +44,9 @@
 #define SEMAPHORE_TAKE(X) if (xSemaphoreTake(_xSemaphore, 1000 / portTICK_PERIOD_MS) != pdTRUE) { return X; }  // Waits max 1000ms
 #define SEMAPHORE_GIVE() xSemaphoreGive(_xSemaphore);
 #elif defined(ESP8266)
+#define SEMAPHORE_TAKE(X) void()
+#define SEMAPHORE_GIVE() void()
+#elif defined(USE_RP2040)
 #define SEMAPHORE_TAKE(X) void()
 #define SEMAPHORE_GIVE() void()
 #endif


### PR DESCRIPTION
RP2040: Add support for the RP2040.

This patch is a small patch that adds in the required ifdefs to make the client work on the RP2040 platform.

It requires the use of the "AsyncTCP_RP2040W" package from here:
https://github.com/khoih-prog/AsyncTCP_RP2040W

This pull request is being done in tandem with the main pull request on esphome here:
https://github.com/esphome/esphome/pull/5305
