### PR TITLE
Bump AsyncTCP-esphome version and add libretiny to platforms list

### DIFF
--- a/library.json
+++ b/library.json
@@ -25,8 +25,8 @@
     {
       "owner": "esphome",
       "name": "AsyncTCP-esphome",
-      "version": "^2.0.1",
-      "platforms": "espressif32"
+      "version": "^2.1.3",
+      "platforms": ["espressif32", "libretiny"]
     }
   ]
 }


### PR DESCRIPTION
Due to the missing platform, the mqtt tests are failing in ESPHome because the dependency is not installed for the libretiny platform.

https://github.com/esphome/esphome/actions/runs/8904504751/job/24453893049?pr=6648